### PR TITLE
Gitignore de webdriverio

### DIFF
--- a/ajenos_a_laravel/webdriverio/.gitignore
+++ b/ajenos_a_laravel/webdriverio/.gitignore
@@ -1,0 +1,1 @@
+errorShots


### PR DESCRIPTION
Se ha creado un gitignore para evitar la acumulación de las capturas de error